### PR TITLE
chore: add requirements.txt

### DIFF
--- a/Lasse/requirements.txt
+++ b/Lasse/requirements.txt
@@ -1,0 +1,3 @@
+asyncio==3.4.3
+pyasn1==0.6.1
+pysnmp==7.1.17


### PR DESCRIPTION
hab ne requirements.txt hinzugefügt via `pip freeze > requirements.txt` 

nicht 100% sicher ob das auch die richtigen packages sind aber script lieft ja gut durch. 

